### PR TITLE
Show all trees in the Debug output.

### DIFF
--- a/src/SynDiffix.Debug/Program.fs
+++ b/src/SynDiffix.Debug/Program.fs
@@ -23,7 +23,8 @@ let rec private collectRoots (root: Tree) =
 [<EntryPoint>]
 let main argv =
   let arguments = parseArguments argv
-  let result = transform arguments
+  let treeCacheLevel = if arguments.Verbose then arguments.CsvColumns.Length else 1
+  let result = transform treeCacheLevel arguments
 
   let debugTrees =
     if arguments.Verbose then

--- a/src/SynDiffix/Engine.fs
+++ b/src/SynDiffix/Engine.fs
@@ -68,7 +68,7 @@ let private printScores (scores: float[,]) =
 
   eprintfn ""
 
-let transform (arguments: ParsedArguments) =
+let transform treeCacheLevel (arguments: ParsedArguments) =
   let countStrategy =
     createCountStrategy arguments.AidColumns arguments.BucketizationParams.RangeLowThreshold
 
@@ -102,6 +102,8 @@ let transform (arguments: ParsedArguments) =
 
   let forest =
     Forest(rows, dataConvertors, anonContext, arguments.BucketizationParams, columnNames, countStrategy)
+
+  forest.SetCacheLevel treeCacheLevel
 
   let allColumns = [ 0 .. forest.Dimensions - 1 ]
 

--- a/src/SynDiffix/Forest.fs
+++ b/src/SynDiffix/Forest.fs
@@ -415,6 +415,7 @@ type Forest
 
   let mappedRows = rows |> Array.map (Tree.mapRow dataConvertors nullMappings)
 
+  let mutable cacheLevel = 1
   let treeCache = Dictionary<Combination, Tree>(LanguagePrimitives.FastGenericEqualityComparer)
 
   let rec getTree (combination: Combination) =
@@ -493,12 +494,14 @@ type Forest
   member this.GetTree(combination: Combination) =
     let tree = getTree combination
 
-    // To reduce memory usage, drop multi-dimensional trees from the cache between invocations.
+    // To reduce memory usage, drop trees larger than `cacheLevel` from the cache between invocations.
     treeCache.Keys
-    |> Seq.filter (Array.length >> ((<>) 1))
+    |> Seq.filter (Array.length >> ((<) cacheLevel))
     |> Seq.iter (treeCache.Remove >> ignore)
 
     tree
 
   member this.GetAvailableTrees() =
     treeCache |> Seq.map (fun pair -> pair.Value) |> Seq.toList
+
+  member this.SetCacheLevel level = cacheLevel <- level

--- a/src/SynDiffix/Program.fs
+++ b/src/SynDiffix/Program.fs
@@ -5,6 +5,6 @@ open SynDiffix.Engine
 
 [<EntryPoint>]
 let main argv =
-  let result = argv |> parseArguments |> transform
+  let result = argv |> parseArguments |> transform 1
   Csv.toString result.Columns result.SynRows |> printfn "%s"
   0


### PR DESCRIPTION
This will keep the Debug Visualizer working.