### PR TITLE
Avoid 2 newlines at end of CSV output

### DIFF
--- a/src/SynDiffix/Program.fs
+++ b/src/SynDiffix/Program.fs
@@ -7,7 +7,7 @@ open SynDiffix.Engine
 let main argv =
   try
     let result = argv |> parseArguments |> transform 1
-    Csv.toString result.Columns result.SynRows |> printfn "%s"
+    Csv.toString result.Columns result.SynRows |> printf "%s"
     0
   with ex ->
     eprintfn "ERROR: %s" ex.Message


### PR DESCRIPTION
Tiny bugfix which I spotted because pandas complained about this. `Csv.toString` already has a trailing newline so no need to add another one.