### PR TITLE
Fix the calculation of the thresholds' mean.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 1.0.2
+
+- Fixed a bug in the computation of low-count/range/singularity thresholds' mean.
+
 ### Version 1.0.1
 
 - Fixed conversion bug when generating boolean microdata.

--- a/src/SynDiffix/Anonymizer.fs
+++ b/src/SynDiffix/Anonymizer.fs
@@ -221,9 +221,9 @@ let isLowCount salt (lowCountParams: LowCountParams) (aidTrackers: (int64 * Hash
     else
       let thresholdNoise = generateNoise salt "suppress" lowCountParams.LayerSD [ seed ]
 
-      // `LowMeanGap` is the number of (total!) standard deviations between `LowThreshold` and desired mean
+      // `LowMeanGap` is the number of standard deviations between `LowThreshold` and desired mean
       let thresholdMean =
-        lowCountParams.LowMeanGap * lowCountParams.LayerSD * sqrt (2.0)
+        lowCountParams.LowMeanGap * lowCountParams.LayerSD
         + float lowCountParams.LowThreshold
 
       let threshold = thresholdNoise + thresholdMean


### PR DESCRIPTION
The thresholds' noise only uses one noise layer, so it doesn't need any scaling.